### PR TITLE
Fixing for progressbar 3.6.2

### DIFF
--- a/main-draw.py
+++ b/main-draw.py
@@ -315,7 +315,7 @@ if __name__ == "__main__":
             training_loss = 0.0
 
             widgets = ["epoch #%d|" % epoch, Percentage(), Bar(), ETA()]
-            pbar = ProgressBar(FLAGS.updates_per_epoch, widgets=widgets)
+            pbar = ProgressBar(max_value = FLAGS.updates_per_epoch, widgets=widgets)
             pbar.start()
             for i in range(FLAGS.updates_per_epoch):
                 pbar.update(i)

--- a/main-gan.py
+++ b/main-gan.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
             generator_loss = 0.0
 
             widgets = ["epoch #%d|" % epoch, Percentage(), Bar(), ETA()]
-            pbar = ProgressBar(FLAGS.updates_per_epoch, widgets=widgets)
+            pbar = ProgressBar(max_value = FLAGS.updates_per_epoch, widgets=widgets)
             pbar.start()
             for i in range(FLAGS.updates_per_epoch):
                 pbar.update(i)

--- a/main-vae.py
+++ b/main-vae.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
             training_loss = 0.0
 
             widgets = ["epoch #%d|" % epoch, Percentage(), Bar(), ETA()]
-            pbar = ProgressBar(FLAGS.updates_per_epoch, widgets=widgets)
+            pbar = ProgressBar(max_value = FLAGS.updates_per_epoch, widgets=widgets)
             pbar.start()
             for i in range(FLAGS.updates_per_epoch):
                 pbar.update(i)


### PR DESCRIPTION
An update to the progressbar python library breaks the script since the first argument is now `min_value` instead of `max_value` so it is now specified
